### PR TITLE
리팩토링 & 버그 픽스

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ http://localhost:3000/
 
 
 ### 프로젝트 구조
-프로젝트에 사용: Vite, React, ts
-UI: tailwind, headlessui, clsx, scss
-클라이언트 전역 상태관리: zustand
-api 관련: axios, react-query, query-key-factory, qs
-포멧팅, 린팅: eslint, prettier
-유틸성: lodash-es, big.js(소숫점 연산), zod(validation), ts-pattern(필요할 것 같아서 설치했는데 삭제 못함)
+- 프로젝트에 사용: Vite, React, ts
+- UI: tailwind, headlessui, clsx, scss
+- 클라이언트 전역 상태관리: zustand
+- api 관련: axios, react-query, query-key-factory, qs
+- 포멧팅, 린팅: eslint, prettier
+- 유틸성: lodash-es, big.js(소숫점 연산), zod(validation), ts-pattern(필요할 것 같아서 설치했는데 삭제 못함)
 
 **북마크**
 - msw 로 모킹하여 진행
@@ -33,7 +33,8 @@ api 관련: axios, react-query, query-key-factory, qs
 - 타입은 swagger 기준으로 자동생성 함
 
 **폴더 구조**
-<img width="185" alt="image" src="https://github.com/NariP/crypto-gecko/assets/23569208/bd88e144-82e5-47df-9476-c64759a8fa81">
+<img style="display: block;" width="185" alt="image" src="https://github.com/NariP/crypto-gecko/assets/23569208/bd88e144-82e5-47df-9476-c64759a8fa81">
+
 - @types: 사용하는 타입들
 - apis: api 코드 모음
 - components: 공용컴포넌트
@@ -47,7 +48,12 @@ api 관련: axios, react-query, query-key-factory, qs
 - stores: zustand store
 - utils: 유틸 함수들
 
+**페이지 구조**
+- Page > contents(페이지를 구성하는 api 데이터 사용, 로더 표시) > section
+- GET 에러 발생 > 글로벌 에러 UI 표시 (기본 설정)
+- Mutation 에러 발생 > mutation 사용처에서 처리 또는 에러 토스트 (기본 설정)
+- JS 에러 발생 > 글로벌 에러 UI 표시
 
-가격계산 부분
+**가격계산 부분**
 - 암호화폐 부분 인풋에 0을 넣으면 krw 여도 0이 입력됨
 - 대신 krw 인 경우 인풋에 0 입력 안됨

--- a/src/apis/bookmarks.ts
+++ b/src/apis/bookmarks.ts
@@ -2,9 +2,8 @@ import axios from '@/libs/axios';
 import type { ApiRes } from '@/libs/axios/axios.types';
 
 /** Bookmark 한 코인을 조회하는 API */
-export const getBookmarks = async () => {
-  const res = await axios.get<any, ApiRes<{ bookmarks: string[] }>>('/bookmarks');
-  return res.data;
+export const getBookmarks = () => {
+  return axios.get<any, ApiRes<{ bookmarks: string[] }>>('/bookmarks');
 };
 
 /** Bookmark 등록하는 API */

--- a/src/components/TextInput.tsx/TextInput.module.scss
+++ b/src/components/TextInput.tsx/TextInput.module.scss
@@ -1,0 +1,16 @@
+.field_wrapper {
+  @apply w-full md:w-[calc(50%_-_4px)];
+}
+
+.input_wrapper {
+  @apply border border-gray-300 rounded-[8px] flex items-center overflow-hidden has-[:focus]:border-base-black
+}
+
+
+.input {
+  @apply px-[8px] py-[12px] flex-1 text-gray-800 text-body1-bold;
+}
+
+.input_error {
+  @apply text-label2-regular text-gray-500 pl-[4px] pt-[4px] h-[16px];
+}

--- a/src/components/TextInput.tsx/TextInput.tsx
+++ b/src/components/TextInput.tsx/TextInput.tsx
@@ -1,0 +1,50 @@
+import { CSSProperties, type InputHTMLAttributes, forwardRef } from 'react';
+import clsx from 'clsx';
+import styles from './TextInput.module.scss';
+
+interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** error text 또는 helperText */
+  helperText?: string;
+  /** 에러 여부 */
+  isError?: boolean;
+  startDecorator?: React.ReactNode;
+  endDecorator?: React.ReactNode;
+  InputProps?: { className?: string; style?: CSSProperties };
+}
+
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  (
+    {
+      helperText,
+      isError = false,
+      startDecorator,
+      endDecorator,
+      className,
+      style,
+      InputProps,
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <div className={clsx(styles.field_wrapper, className)} style={style}>
+        <div className={styles.input_wrapper}>
+          {startDecorator}
+          <input
+            ref={ref}
+            className={clsx(styles.input, InputProps?.className)}
+            style={InputProps?.style}
+            type="text"
+            {...rest}
+          />
+          {endDecorator}
+        </div>
+        <p className={clsx(styles.input_error, isError && 'text-error-default')}>{helperText}</p>
+      </div>
+    );
+  }
+);
+
+TextInput.displayName = 'TextInput';
+
+export default TextInput;

--- a/src/components/TextInput.tsx/index.ts
+++ b/src/components/TextInput.tsx/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TextInput';

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -9,7 +9,7 @@ export const useBookmarksData = (options?: { enabled?: boolean }) => {
     ...options,
   });
 
-  const bookmarks = data?.bookmarks || [];
+  const bookmarks = data?.data?.bookmarks || [];
   return { bookmarks, bookMarksSet: new Set(bookmarks) };
 };
 

--- a/src/libs/Big/Big.ts
+++ b/src/libs/Big/Big.ts
@@ -1,0 +1,31 @@
+import RawBig, { type BigSource } from 'big.js';
+
+type ResSafeBig =
+  | { isSuccess: true; bigNum: RawBig.Big; value: BigSource }
+  | { isSuccess: false; value: BigSource; fallback: string | number };
+
+interface IBig {
+  (value: BigSource): {
+    safeBig(fallback: string | number): ResSafeBig;
+    big: () => RawBig.Big;
+  };
+}
+
+const Big: IBig = (value: BigSource) => {
+  return {
+    // bigNumber 생성자 생성 오류 발생시 인스턴스를 생성하지 않는다.
+    safeBig(fallback: string | number) {
+      try {
+        const bigNum = new RawBig(value);
+        return { isSuccess: true, bigNum, value };
+      } catch (e) {
+        return { isSuccess: false, fallback, value };
+      }
+    },
+    big() {
+      return new RawBig(value);
+    },
+  };
+};
+
+export default Big;

--- a/src/libs/Big/index.ts
+++ b/src/libs/Big/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Big';

--- a/src/pages/CryptoRoot.tsx
+++ b/src/pages/CryptoRoot.tsx
@@ -16,7 +16,7 @@ const CryptoRoot = () => {
     resetHomeToolbar();
   }, [resetHomeToolbar, restCurrencyStore]);
 
-  if (pathname === '/') {
+  if (pathname === '/crypto' || pathname === '/crypto/') {
     return <Navigate replace to="/crypto/market" />;
   }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { Navigate, createBrowserRouter } from 'react-router-dom';
 import CryptoBookmarkPage from '@/pages/CryptoBookmarkPage';
 import CryptoDetailPage from '@/pages/CryptoDetailPage';
 import CryptoRoot from '@/pages/CryptoRoot';
@@ -10,6 +10,10 @@ const router = createBrowserRouter(
   [
     {
       path: '/',
+      element: <Navigate to="/crypto/market" />,
+    },
+    {
+      path: '/crypto',
       element: <CryptoRoot />,
       children: [
         {

--- a/src/screens/cryptoDetail/sections/CryptoConverterSection.module.scss
+++ b/src/screens/cryptoDetail/sections/CryptoConverterSection.module.scss
@@ -1,19 +1,3 @@
-.field_wrapper {
-  @apply w-full md:w-[calc(50%_-_4px)];
-}
-
-.input_wrapper {
-  @apply border border-gray-300 rounded-[8px] flex items-center overflow-hidden;
-}
-
 .input_label {
   @apply text-gray-600 text-body1-bold px-[8px] py-[4px];
-}
-
-.input {
-  @apply px-[8px] py-[12px] flex-1 text-gray-800 text-body1-bold;
-}
-
-.input_error {
-  @apply text-label2-regular text-error-default pl-[4px] pt-[4px] h-[16px];
 }

--- a/src/screens/cryptoDetail/sections/CryptoConverterSection.tsx
+++ b/src/screens/cryptoDetail/sections/CryptoConverterSection.tsx
@@ -134,9 +134,6 @@ const CryptoConverterSection = ({ data }: CryptoConverterSectionProps) => {
             </label>
           }
           onChange={onChangeCryptoHandler}
-          onKeyDown={() => {
-            resetError('cryptoCurrency');
-          }}
         />
         <TextInput
           id="currency"
@@ -157,8 +154,6 @@ const CryptoConverterSection = ({ data }: CryptoConverterSectionProps) => {
           onChange={onChangeCurrencyHandelr}
           onPaste={onPasteCurrencyHandler}
           onKeyDown={e => {
-            resetError('currency');
-
             if (e.key === '.') {
               e.preventDefault();
             }

--- a/src/screens/cryptoDetail/sections/CryptoConverterSection.tsx
+++ b/src/screens/cryptoDetail/sections/CryptoConverterSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import Big from 'big.js';
 import { type ZodError, z } from 'zod';
+import TextInput from '@/components/TextInput.tsx';
 import usePrevState from '@/hooks/usePrevState';
 import { useCurrencyStore } from '@/stores/useCurrencyStore';
 import { toUpperCoinSymbol } from '@/utils/crypto';
@@ -121,53 +122,48 @@ const CryptoConverterSection = ({ data }: CryptoConverterSectionProps) => {
     <section className="contents_section">
       <h3 className="text-base-text text-title2-bold pb-[16px]">{symbol} 가격 계산</h3>
       <div className="flex flex-wrap gap-[8px]">
-        <div className={styles.field_wrapper}>
-          <div className={styles.input_wrapper}>
-            <input
-              className={styles.input}
-              type="text"
-              id="cryptoCurrency"
-              placeholder="숫자를 입력해주세요."
-              value={cryptoPrice}
-              onChange={onChangeCryptoHandler}
-              onKeyDown={() => {
-                resetError('cryptoCurrency');
-              }}
-            />
+        <TextInput
+          placeholder="숫자를 입력해주세요."
+          id="cryptoCurrency"
+          value={cryptoPrice}
+          isError={!!errors.cryptoCurrency}
+          helperText={errors.cryptoCurrency}
+          endDecorator={
             <label htmlFor="cryptoCurrency" className={styles.input_label}>
               {symbol}
             </label>
-          </div>
-          <p className={styles.input_error}>{errors.cryptoCurrency}</p>
-        </div>
-
-        <div className={styles.field_wrapper}>
-          <div className={styles.input_wrapper}>
+          }
+          onChange={onChangeCryptoHandler}
+          onKeyDown={() => {
+            resetError('cryptoCurrency');
+          }}
+        />
+        <TextInput
+          id="currency"
+          placeholder="숫자를 입력해주세요."
+          value={currencyPrice}
+          isError={!!errors.currency}
+          helperText={errors.currency}
+          startDecorator={
             <span className="pl-[4px] text-gray-500 text-label1-bold">
               {localeSymbol(currency)}
             </span>
-            <input
-              className={styles.input}
-              type="text"
-              id="currency"
-              placeholder="숫자를 입력해주세요."
-              value={currencyPrice}
-              onChange={onChangeCurrencyHandelr}
-              onPaste={onPasteCurrencyHandler}
-              onKeyDown={e => {
-                resetError('currency');
-
-                if (e.key === '.') {
-                  e.preventDefault();
-                }
-              }}
-            />
+          }
+          endDecorator={
             <label htmlFor="currency" className={styles.input_label}>
               {currency.toUpperCase()}
             </label>
-          </div>
-          <p className={styles.input_error}>{errors.currency}</p>
-        </div>
+          }
+          onChange={onChangeCurrencyHandelr}
+          onPaste={onPasteCurrencyHandler}
+          onKeyDown={e => {
+            resetError('currency');
+
+            if (e.key === '.') {
+              e.preventDefault();
+            }
+          }}
+        />
       </div>
       <ul className="text-gray-600 bg-gray-100 text-label2-regular rounded-[4px] p-[8px] mt-[16px] md:mt-[8px]">
         <li className="text-inherit">

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -10,7 +10,7 @@ export const cryptoPercentage = (percentage: number) => {
   return parseFloat(safeValue.toFixed(1).toString()).toFixed(1);
 };
 
-/** percentage 값에 따라 컬러 변경 반올림한 경우는 어쩌지 */
+/** percentage 값에 따라 컬러 변경 반올림한 경우는 어쩌지(0.003, -0.003 했을 때 똑같이 0.00 인데 이거 색 처리를 어쩔지 고민하다가 안 지움) */
 export const cryptoPercentageColor = (percentage: number) => {
   const safeValue = percentage ?? 0;
   if (safeValue > 0) {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,3 +1,5 @@
+import Big from '@/libs/Big';
+
 /**
  * 심볼을 대문자로 변경하는 함수
  * - 공용으로 뺀 이유: 심볼은 페이지 내에서 표시될 때 대문자만 사용한다고 가정했기 때문
@@ -22,4 +24,36 @@ export const cryptoPercentageColor = (percentage: number) => {
   }
 
   return 'text-gray-600';
+};
+
+// 선택한 통화 가격 -> 코인 갯수로 변경하는 함수
+export const covertCryptoToCurrency = (
+  crypto: string,
+  coinPriceInCurrency: number,
+  fallback = ''
+) => {
+  const bigCrypto = Big(crypto).safeBig(fallback);
+  const bigCoinPriceInCurrency = Big(coinPriceInCurrency).safeBig(fallback);
+
+  if (bigCrypto.isSuccess && bigCoinPriceInCurrency.isSuccess) {
+    return bigCrypto.bigNum.times(bigCoinPriceInCurrency.bigNum).toFixed(2, 1);
+  }
+
+  return fallback;
+};
+
+// 코인 갯수 -> 선택한 통화 가격으로 변경하는 함수
+export const convertCurrencyToCrypto = (
+  currentPrice: string,
+  coinPriceInCurrency: number,
+  fallback = ''
+) => {
+  const bigCurrentPrice = Big(currentPrice).safeBig(fallback);
+  const bigCoinPriceInCurrency = Big(coinPriceInCurrency).safeBig(fallback);
+
+  if (bigCurrentPrice.isSuccess && bigCoinPriceInCurrency.isSuccess) {
+    return bigCurrentPrice.bigNum.div(bigCoinPriceInCurrency.bigNum).toFixed(8, 1);
+  }
+
+  return fallback;
 };


### PR DESCRIPTION
**코인 상세 페이지**
1. Input UI 로직 분리 (에러 메세지 표시)
2. resetError 시점 변경(실제로 값이 변경되었을 때만 reset)
3. Big 라이브러리 safe 하게 사용하도록 래핑
4. 가격 계산 로직 중 중복되는 부분 코드 정리, 한 인풋당 1 handelr 1 schema 사용하도록 schema 통합

**Bug fix**
1. useQuery 관련 이슈 수정 [3f32c6a](https://github.com/NariP/crypto-gecko/pull/1/commits/3f32c6aca35cad3aba106384b765e1f8db450036)
2. 중첩 라우팅 관련 이슈 수정 [cacf256](https://github.com/NariP/crypto-gecko/pull/1/commits/cacf2568ac5a5cbc155a0c47d6914a16e625a729)